### PR TITLE
fix: strip extra spaces and punctuation from search input

### DIFF
--- a/client/src/components/QuickSearch.tsx
+++ b/client/src/components/QuickSearch.tsx
@@ -15,7 +15,14 @@ export function QuickSearch({ className = "" }: QuickSearchProps) {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
+      // Strip leading/trailing punctuation and collapse whitespace
+      const sanitized = searchQuery
+        .trim()
+        .replace(/^[,;:.!?]+|[,;:.!?]+$/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (!sanitized) return;
+      navigate(`/search?q=${encodeURIComponent(sanitized)}`);
     }
   };
 

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -182,12 +182,19 @@ export default function SearchPage() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      const trimmed = searchQuery.trim();
-      setSubmittedQuery(trimmed);
+      // Strip leading/trailing punctuation (commas, periods, semicolons, etc.) and collapse whitespace
+      const sanitized = searchQuery
+        .trim()
+        .replace(/^[,;:.!?]+|[,;:.!?]+$/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (!sanitized) return;
+      setSearchQuery(sanitized);
+      setSubmittedQuery(sanitized);
       setCurrentPage(1);
       setShowSuggestions(false);
       setIsUserTyping(false);
-      pushUrl({ q: trimmed });
+      pushUrl({ q: sanitized });
     }
   };
 


### PR DESCRIPTION
## Summary
Sanitizes user search input by stripping leading/trailing punctuation (commas, semicolons, periods, colons, exclamation/question marks) and collapsing multiple whitespace characters into a single space.

Fixes #75

## Changes
- `client/src/pages/search.tsx`: Added input sanitization in `handleSearch` before submitting the query. Also updates the displayed search query to the cleaned version.
- `client/src/components/QuickSearch.tsx`: Applied the same sanitization for consistency across both search entry points.

## Testing
- Verified that inputs like `"  hello  world  "` become `"hello world"`
- Verified that inputs like `",Torah,"` become `"Torah"`
- Verified that inputs like `"...Shabbat..."` become `"Shabbat"`
- Empty input after sanitization is blocked from submitting