### PR TITLE
Fix stacked layout: show Hebrew before English

### DIFF
--- a/client/src/components/text/bilingual-display.tsx
+++ b/client/src/components/text/bilingual-display.tsx
@@ -10,20 +10,20 @@ export function BilingualDisplay({ text }: BilingualDisplayProps) {
   return (
     <div className="bg-white rounded-lg shadow-sm border border-sepia-200 p-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* English Text (Left Side) */}
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold text-talmud-brown border-b border-sepia-200 pb-2">
-            English Translation
-          </h3>
-          <EnglishText text={text.englishText} />
-        </div>
-
-        {/* Hebrew Text (Right Side) */}
-        <div className="space-y-6">
+        {/* Hebrew Text (First on Mobile/Stacked, Right Side on Desktop) */}
+        <div className="space-y-6 lg:order-2">
           <h3 className="text-lg font-semibold text-talmud-brown border-b border-sepia-200 pb-2">
             טקסט עברי
           </h3>
           <HebrewText text={text.hebrewText} />
+        </div>
+
+        {/* English Text (Second on Mobile/Stacked, Left Side on Desktop) */}
+        <div className="space-y-6 lg:order-1">
+          <h3 className="text-lg font-semibold text-talmud-brown border-b border-sepia-200 pb-2">
+            English Translation
+          </h3>
+          <EnglishText text={text.englishText} />
         </div>
       </div>
     </div>

--- a/client/src/components/text/sectioned-bilingual-display.tsx
+++ b/client/src/components/text/sectioned-bilingual-display.tsx
@@ -491,28 +491,28 @@ export function SectionedBilingualDisplay({ text, onSectionVisible }: SectionedB
               })()}
               
               <div className="text-display flex flex-col lg:flex-row gap-6">
-                {/* English Section (First on Mobile, Left Side on Desktop) */}
-                <div className="text-column space-y-3 lg:order-1">
-                  {section.englishHtml && (
-                    <div className="english-text text-foreground">
-                      <div 
-                        dangerouslySetInnerHTML={{ __html: section.englishHtml }}
-                      />
-                    </div>
-                  )}
-                </div>
-
-                {/* Hebrew Section (Second on Mobile, Right Side on Desktop) */}
+                {/* Hebrew Section (First on Mobile/Stacked, Right Side on Desktop) */}
                 <div className="text-column space-y-3 lg:order-2">
                   {section.hebrewLines.length > 0 && (
                     <div className={`hebrew-text text-foreground ${getHebrewFontClass()}`}>
                       {section.hebrewLines.map((lineHtml, lineIndex) => (
-                        <p 
-                          key={lineIndex} 
+                        <p
+                          key={lineIndex}
                           className={`leading-relaxed ${lineIndex < section.hebrewLines.length - 1 ? 'mb-6 lg:mb-8' : 'mb-2'}`}
                           dangerouslySetInnerHTML={{ __html: lineHtml }}
                         />
                       ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* English Section (Second on Mobile/Stacked, Left Side on Desktop) */}
+                <div className="text-column space-y-3 lg:order-1">
+                  {section.englishHtml && (
+                    <div className="english-text text-foreground">
+                      <div
+                        dangerouslySetInnerHTML={{ __html: section.englishHtml }}
+                      />
                     </div>
                   )}
                 </div>
@@ -531,28 +531,28 @@ export function SectionedBilingualDisplay({ text, onSectionVisible }: SectionedB
             </div>
             
             <div className="text-display flex flex-col lg:flex-row gap-6 opacity-60">
-              {/* English Continuation (First on Mobile, Left Side on Desktop) */}
-              <div className="text-column space-y-3 lg:order-1">
-                {text.nextPageFirstSection.english.trim() && (
-                  <div className="english-text text-muted-foreground">
-                    <div 
-                      dangerouslySetInnerHTML={{ __html: formatEnglishText(processEnglishText(text.nextPageFirstSection.english)) }}
-                    />
-                  </div>
-                )}
-              </div>
-
-              {/* Hebrew Continuation (Second on Mobile, Right Side on Desktop) */}
+              {/* Hebrew Continuation (First on Mobile/Stacked, Right Side on Desktop) */}
               <div className="text-column space-y-3 lg:order-2">
                 {text.nextPageFirstSection.hebrew.trim() && (
                   <div className={`hebrew-text text-muted-foreground ${getHebrewFontClass()}`}>
                     {processHebrewText(text.nextPageFirstSection.hebrew).split('\n').filter(line => line.trim()).map((line, lineIndex, array) => (
-                      <p 
-                        key={lineIndex} 
+                      <p
+                        key={lineIndex}
                         className={`leading-relaxed ${lineIndex < array.length - 1 ? 'mb-6 lg:mb-8' : 'mb-2'}`}
                         dangerouslySetInnerHTML={{ __html: line.trim() }}
                       />
                     ))}
+                  </div>
+                )}
+              </div>
+
+              {/* English Continuation (Second on Mobile/Stacked, Left Side on Desktop) */}
+              <div className="text-column space-y-3 lg:order-1">
+                {text.nextPageFirstSection.english.trim() && (
+                  <div className="english-text text-muted-foreground">
+                    <div
+                      dangerouslySetInnerHTML={{ __html: formatEnglishText(processEnglishText(text.nextPageFirstSection.english)) }}
+                    />
                   </div>
                 )}
               </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -175,12 +175,12 @@
   }
   
   .layout-side-by-side .text-display .text-column:first-child {
-    width: 65%;
+    width: 35%;
     padding: 0 0.75rem;
   }
-  
+
   .layout-side-by-side .text-display .text-column:last-child {
-    width: 35%;
+    width: 65%;
     padding: 0 0.75rem;
   }
   
@@ -202,12 +202,12 @@
     }
     
     .layout-side-by-side .text-display .text-column:first-child {
-      width: 65% !important;
+      width: 35% !important;
       padding: 0 0.5rem;
     }
-    
+
     .layout-side-by-side .text-display .text-column:last-child {
-      width: 35% !important;
+      width: 65% !important;
       padding: 0 0.5rem;
     }
 


### PR DESCRIPTION
## Summary

- Fixes the stacked layout for Talmud and Bible text so Hebrew appears before English (issue #44)
- Swaps the DOM order of Hebrew and English sections in both `sectioned-bilingual-display.tsx` and `bilingual-display.tsx`
- Uses `lg:order-1` / `lg:order-2` CSS classes to preserve the desktop side-by-side layout (English left, Hebrew right)
- Updates corresponding CSS width rules in `index.css` to match the new DOM order

## Changes

**`sectioned-bilingual-display.tsx`**
- Moved Hebrew section before English section in the DOM (both main content and next-page continuation)
- Hebrew gets `lg:order-2` (right on desktop), English gets `lg:order-1` (left on desktop)
- In stacked/mobile layout, DOM order is followed → Hebrew now appears first ✓

**`bilingual-display.tsx`**
- Same DOM reorder: Hebrew first, English second
- Added `lg:order-1` and `lg:order-2` classes to maintain desktop layout

**`index.css`**
- Swapped `.text-column:first-child` and `:last-child` width percentages (35%/65%) since Hebrew is now first in DOM

## Test plan

- [ ] Open a Talmud page in stacked layout → Hebrew should appear above English
- [ ] Open a Bible page in stacked layout → Hebrew should appear above English
- [ ] Open a Talmud page in side-by-side layout → English on left (65%), Hebrew on right (35%)
- [ ] Open a Bible page in side-by-side layout → columns should be 50/50
- [ ] Test on mobile viewport → Hebrew appears first
- [ ] Test next-page continuation section in stacked layout → Hebrew first

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)