### PR TITLE
Add 'ignoramuses' → 'commoners' term mapping

### DIFF
--- a/shared/data/term-replacements.json
+++ b/shared/data/term-replacements.json
@@ -44,7 +44,8 @@
         "malicious speech": "lashon hara",
         "leper": "metzora",
         "leprosy": "tzara'at",
-        "ignoramus": "am ha'aretz"
+        "ignoramus": "am ha'aretz",
+        "ignoramuses": "commoners"
       }
     },
     "people": {


### PR DESCRIPTION
## Summary

- Adds `"ignoramuses": "commoners"` to the `hebrew_terms` category in `term-replacements.json`
- The singular form `"ignoramus": "am ha'aretz"` already existed; this adds the plural form as requested

## Test plan

- [ ] Search for a Talmud page containing the word "ignoramuses" and verify it displays as "commoners"

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)